### PR TITLE
add configHook option for ng serve

### DIFF
--- a/lib/src/plus-dev-server/index.ts
+++ b/lib/src/plus-dev-server/index.ts
@@ -1,6 +1,8 @@
 import { Path, getSystemPath, virtualFs } from '@angular-devkit/core';
 import * as path from 'path';
 import * as fs from 'fs';
+import { ConfigHookFn } from '../ext/hook';
+import { loadHook } from '../ext/load-hook';
 
 import { DevServerBuilder as DevServerBuilderBase, BrowserBuilderSchema as BrowserBuilderSchemaBase   } from '@angular-devkit/build-angular';
 const webpackMerge = require('webpack-merge');
@@ -9,6 +11,7 @@ export interface BrowserBuilderSchema extends BrowserBuilderSchemaBase {
   extraWebpackConfig: string;
   singleBundle: boolean;
   bundleStyles: boolean;
+  configHook: string;
 }
 
 export class PlusDevServerBuilder extends DevServerBuilderBase {
@@ -38,6 +41,11 @@ export class PlusDevServerBuilder extends DevServerBuilderBase {
       const filePath = path.resolve(getSystemPath(projectRoot), this.localOptions.extraWebpackConfig);
       const additionalConfig = require(filePath);
       config = webpackMerge([config, additionalConfig]);
+    }
+
+    if (this.localOptions.configHook) {
+      const hook = loadHook<ConfigHookFn>(this.localOptions.configHook);
+      config = hook(config);
     }
 
     return config;

--- a/lib/src/plus-dev-server/schema.json
+++ b/lib/src/plus-dev-server/schema.json
@@ -13,6 +13,13 @@
       "description": "Generate just one bundle",
       "default": false
     },
+
+    "configHook": {
+      "type": "string",
+      "description": "es module exporting a configHook function (default export).",
+      "default": ""
+    },
+
     "bundleStyles": {
       "type": "boolean",
       "description": "Used conjunction with 'singleBundle' to explizitly not bundle styles",

--- a/lib/src/plus/schema.json
+++ b/lib/src/plus/schema.json
@@ -22,7 +22,7 @@
     
     "configHook": {
       "type": "string",
-      "description": "es module exporting a configHook function (default export). Just used for ng build; not for ng serve",
+      "description": "es module exporting a configHook function (default export).",
       "default": ""
     },
 


### PR DESCRIPTION
Hello,

I am surprised `configHook` is currently not available for `ng serve`, only for `ng build`.
I am opening this PR to add support for `configHook` in `ng serve` when ngx-build-plus is used in a project.

Thank you!