### PR TITLE
Allowing webpack devServer config to be extended.

### DIFF
--- a/lib/src/plus-dev-server/index.ts
+++ b/lib/src/plus-dev-server/index.ts
@@ -42,6 +42,18 @@ export class PlusDevServerBuilder extends DevServerBuilderBase {
 
     return config;
   }
+
+  _buildServerConfig(root, projectRoot, options, browserOptions) {
+    let devServerConfig = super._buildServerConfig(root, projectRoot, options, browserOptions);
+
+    if (this.localOptions.extraWebpackConfig) {
+      const filePath = path.resolve(core_1.getSystemPath(projectRoot), this.localOptions.extraWebpackConfig);
+      const additionalConfig = require(filePath).devServer || {};
+      devServerConfig = webpackMerge([devServerConfig, additionalConfig]);
+    }
+
+    return devServerConfig;
+  }
 }
 
 export default PlusDevServerBuilder;


### PR DESCRIPTION
First off, I've really been enjoying using this project, thanks for your work on it!

This PR makes it so that [webpack dev server configuration](https://webpack.js.org/configuration/dev-server/) inside of the extra webpack config is actually used when you run `ng serve`. The @angular-devkit/angular-builder package actually [overwrites the devServer portion of the webpack config](https://github.com/angular/angular-cli/blob/master/packages/angular_devkit/build_angular/src/dev-server/index.ts#L150) to use [their defaults](https://github.com/angular/angular-cli/blob/master/packages/angular_devkit/build_angular/src/dev-server/index.ts#L198).

So to be able to overwrite the defaults, ngx-build-plus needs to implement its own version of `_buildServerConfig`, which is what I've done in this PR.