### PR TITLE
update definitions in plus/schema.json with angular-cli, accepting ignore in assets

### DIFF
--- a/lib/src/plus/schema.json
+++ b/lib/src/plus/schema.json
@@ -302,6 +302,13 @@
             "output": {
               "type": "string",
               "description": "Absolute path within the output."
+            },
+            "ignore": {
+              "description": "An array of globs to ignore.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           },
           "additionalProperties": false,
@@ -312,7 +319,8 @@
           ]
         },
         {
-          "type": "string"
+          "type": "string",
+          "description": "The file to include."
         }
       ]
     },


### PR DESCRIPTION
Currently using ngx-build-plus you can't ignore some assets, it's missing the attribute "ignore" in assetPattern supported in angular-cli builder.