### PR TITLE
Add preConfig hook to manipulate builder configuration

### DIFF
--- a/lib/src/ext/hook.ts
+++ b/lib/src/ext/hook.ts
@@ -4,6 +4,7 @@ import { BrowserBuilderSchema } from "src/plus-dev-server";
 export type ConfigHookFn = (cfg: object) => object;
 
 export type Plugin = {
+    preConfig?(builderConfig: BuilderConfiguration<BrowserBuilderSchema>): void;
     config?(cfg: object): object;
     pre?(builderConfig: BuilderConfiguration<BrowserBuilderSchema>): void;
     post?(builderConfig: BuilderConfiguration<BrowserBuilderSchema>): void

--- a/lib/src/ext/hook.ts
+++ b/lib/src/ext/hook.ts
@@ -3,7 +3,18 @@ import { BuilderConfiguration } from "@angular-devkit/architect";
 export type ConfigHookFn = (cfg: object) => object;
 
 export type Plugin<O, N> = {
+    /**
+     * Called before webpack configuration is created
+     * Receives the normalized and merged build configuration over multiple targets
+     *
+     * @param normalizedBuilderConfig
+     */
     preConfig?(normalizedBuilderConfig: N): void;
+    /**
+     * Called after webpack configuration was created
+     *
+     * @param cfg
+     */
     config?(cfg: object): object;
     pre?(builderConfig: BuilderConfiguration<O>): void;
     post?(builderConfig: BuilderConfiguration<O>): void

--- a/lib/src/ext/hook.ts
+++ b/lib/src/ext/hook.ts
@@ -1,11 +1,10 @@
 import { BuilderConfiguration } from "@angular-devkit/architect";
-import { BrowserBuilderSchema } from "src/plus-dev-server";
 
 export type ConfigHookFn = (cfg: object) => object;
 
-export type Plugin = {
-    preConfig?(builderConfig: BuilderConfiguration<BrowserBuilderSchema>): void;
+export type Plugin<O, N> = {
+    preConfig?(normalizedBuilderConfig: N): void;
     config?(cfg: object): object;
-    pre?(builderConfig: BuilderConfiguration<BrowserBuilderSchema>): void;
-    post?(builderConfig: BuilderConfiguration<BrowserBuilderSchema>): void
+    pre?(builderConfig: BuilderConfiguration<O>): void;
+    post?(builderConfig: BuilderConfiguration<O>): void
 };

--- a/lib/src/karma/index.ts
+++ b/lib/src/karma/index.ts
@@ -31,6 +31,15 @@ export default class PlusKarmaBuilder extends KarmaBuilder {
         options: PlusNormalizedKarmaBuilderSchema,
     ) {
 
+        let plugin: Plugin | null = null;
+        if (this.localOptions.plugin) {
+            plugin = loadHook<Plugin>(this.localOptions.plugin);
+        }
+
+        if (plugin && plugin.preConfig) {
+            plugin.preConfig(options);
+        }
+
         let config = super.buildWebpackConfig(root, projectRoot, sourceRoot, host, options);
 
         if (this.localOptions.singleBundle) {
@@ -49,11 +58,6 @@ export default class PlusKarmaBuilder extends KarmaBuilder {
             const filePath = path.resolve(getSystemPath(projectRoot), this.localOptions.extraWebpackConfig);
             const additionalConfig = require(filePath);
             config = webpackMerge([config, additionalConfig]);
-        }
-
-        let plugin: Plugin | null = null;
-        if (this.localOptions.plugin) {
-            plugin = loadHook<Plugin>(this.localOptions.plugin);
         }
 
         if (plugin && plugin.config) {

--- a/lib/src/plus-dev-server/index.ts
+++ b/lib/src/plus-dev-server/index.ts
@@ -3,16 +3,17 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { ConfigHookFn, Plugin } from '../ext/hook';
 import { loadHook } from '../ext/load-hook';
+import { PlusBuilderSchema } from 'src/plus/schema';
 
-import { DevServerBuilder as DevServerBuilderBase, BrowserBuilderSchema as BrowserBuilderSchemaBase, DevServerBuilderOptions   } from '@angular-devkit/build-angular';
-import { BuildEvent } from '@angular-devkit/architect';
+import { DevServerBuilder as DevServerBuilderBase, DevServerBuilderOptions as DevServerBuilderOptionsBase } from '@angular-devkit/build-angular';
+import { BuilderConfiguration, BuildEvent } from '@angular-devkit/architect';
 
 import { tap } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 
 const webpackMerge = require('webpack-merge');
 
-export interface BrowserBuilderSchema extends BrowserBuilderSchemaBase {
+export interface DevServerBuilderOptions extends DevServerBuilderOptionsBase {
   extraWebpackConfig: string;
   singleBundle: boolean;
   keepPolyfills: boolean;
@@ -29,12 +30,12 @@ export class PlusDevServerBuilder extends DevServerBuilderBase {
     root: Path,
     projectRoot: Path,
     host: virtualFs.Host<fs.Stats>,
-    options: any,
+    options: PlusBuilderSchema,
   ) {
 
-    let plugin: Plugin | null = null;
+    let plugin: Plugin<DevServerBuilderOptions, PlusBuilderSchema> | null = null;
     if (this.localOptions.plugin) {
-      plugin = loadHook<Plugin>(this.localOptions.plugin);
+      plugin = loadHook<Plugin<DevServerBuilderOptions, PlusBuilderSchema>>(this.localOptions.plugin);
     }
 
     if (plugin && plugin.preConfig) {
@@ -46,7 +47,7 @@ export class PlusDevServerBuilder extends DevServerBuilderBase {
     if (this.localOptions.singleBundle) {
       if (!this.localOptions.keepPolyfills) {
         delete config.entry.polyfills;
-      } 
+      }
       delete config.optimization.runtimeChunk;
       delete config.optimization.splitChunks;
     }
@@ -77,12 +78,12 @@ export class PlusDevServerBuilder extends DevServerBuilderBase {
     return config;
   }
 
-  run(builderConfig: any): Observable<BuildEvent> {
-    
+  run(builderConfig: BuilderConfiguration<DevServerBuilderOptions>): Observable<BuildEvent> {
+
     this.localOptions = builderConfig.options;
-    let plugin: Plugin | null = null;
+    let plugin: Plugin<DevServerBuilderOptions, PlusBuilderSchema> | null = null;
     if (builderConfig.options.plugin) {
-      plugin = loadHook<Plugin>(builderConfig.options.plugin);
+      plugin = loadHook<Plugin<DevServerBuilderOptions, PlusBuilderSchema>>(builderConfig.options.plugin);
     }
 
     if (plugin && plugin.pre) {
@@ -99,7 +100,7 @@ export class PlusDevServerBuilder extends DevServerBuilderBase {
 
   }
 
-  
+
 }
 
 export default PlusDevServerBuilder;

--- a/lib/src/plus-dev-server/index.ts
+++ b/lib/src/plus-dev-server/index.ts
@@ -32,6 +32,15 @@ export class PlusDevServerBuilder extends DevServerBuilderBase {
     options: any,
   ) {
 
+    let plugin: Plugin | null = null;
+    if (this.localOptions.plugin) {
+      plugin = loadHook<Plugin>(this.localOptions.plugin);
+    }
+
+    if (plugin && plugin.preConfig) {
+      plugin.preConfig(options);
+    }
+
     let config = super.buildWebpackConfig(root, projectRoot, host, options);
 
     if (this.localOptions.singleBundle) {
@@ -50,11 +59,6 @@ export class PlusDevServerBuilder extends DevServerBuilderBase {
       const filePath = path.resolve(getSystemPath(projectRoot), this.localOptions.extraWebpackConfig);
       const additionalConfig = require(filePath);
       config = webpackMerge([config, additionalConfig]);
-    }
-
-    let plugin: Plugin | null = null;
-    if (this.localOptions.plugin) {
-      plugin = loadHook<Plugin>(this.localOptions.plugin);
     }
 
     if (plugin && plugin.config) {

--- a/lib/src/plus/index.ts
+++ b/lib/src/plus/index.ts
@@ -47,6 +47,15 @@ export class PlusBuilder extends BrowserBuilder  {
     options: PlusBuilderSchema,
   ) {
 
+    let plugin: Plugin | null = null;
+    if (this.localOptions.plugin) {
+      plugin = loadHook<Plugin>(this.localOptions.plugin);
+    }
+
+    if (plugin && plugin.preConfig) {
+      plugin.preConfig(options);
+    }
+
     let config = super.buildWebpackConfig(root, projectRoot, host, options);
 
     if (this.localOptions.singleBundle) {
@@ -66,11 +75,6 @@ export class PlusBuilder extends BrowserBuilder  {
       const filePath = path.resolve(getSystemPath(projectRoot), this.localOptions.extraWebpackConfig);
       const additionalConfig = require(filePath);
       config = webpackMerge([config, additionalConfig]);
-    }
-
-    let plugin: Plugin | null = null;
-    if (this.localOptions.plugin) {
-      plugin = loadHook<Plugin>(this.localOptions.plugin);
     }
 
     if (plugin && plugin.config) {


### PR DESCRIPTION
The preConfig hook gets the merged and normalized configuration from the builder chain and can change the values before using them to create a webpack config.

Another approach for issue #107 