### PR TITLE
Fix path in package.json script

### DIFF
--- a/lib/schematics/externals/index.ts
+++ b/lib/schematics/externals/index.ts
@@ -135,10 +135,10 @@ function updateScripts(path: string, config: any, tree: Tree, _options: any, _co
 
   // Heuristic for default project
   if (!project.root) {
-    config.scripts['build:externals'] = `ng build --extra-webpack-config ${path}webpack.externals.js --prod ${additionalFlags}`;
+    config.scripts['build:externals'] = `ng build --extra-webpack-config ${path}/webpack.externals.js --prod ${additionalFlags}`;
   }
 
   if (_options.project) {
-    config.scripts[`build:${_options.project}:externals`] = `ng build --extra-webpack-config ${path}webpack.externals.js --prod --project ${_options.project} ${additionalFlags}`;
+    config.scripts[`build:${_options.project}:externals`] = `ng build --extra-webpack-config ${path}/webpack.externals.js --prod --project ${_options.project} ${additionalFlags}`;
   }
 }


### PR DESCRIPTION
Old behavior:

Running the `externals` schematic create a package.json script like this:
`"build:ng-elements:externals": "ng build --extra-webpack-config apps/ng-elementswebpack.externals.js --prod --project ng-elements --single-bundle"`

New behavior:

Running the `externals` schematic create a package.json script like this:
`"build:ng-elements:externals": "ng build --extra-webpack-config apps/ng-elements/webpack.externals.js --prod --project ng-elements --single-bundle"`
