### PR TITLE
Added fix for sourceMap schema validation

### DIFF
--- a/lib/src/browser/schema.json
+++ b/lib/src/browser/schema.json
@@ -131,7 +131,38 @@
     "sourceMap": {
       "type": "boolean",
       "description": "Output sourcemaps.",
-      "default": true
+      "default": true,
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "scripts": {
+              "type": "boolean",
+              "description": "Output sourcemaps for all scripts.",
+              "default": true
+            },
+            "styles": {
+              "type": "boolean",
+              "description": "Output sourcemaps for all styles.",
+              "default": true
+            },
+            "hidden": {
+              "type": "boolean",
+              "description": "Output sourcemaps used for error reporting tools.",
+              "default": false
+            },
+            "vendor": {
+              "type": "boolean",
+              "description": "Resolve vendor packages sourcemaps.",
+              "default": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     },
     "vendorSourceMap": {
       "type": "boolean",


### PR DESCRIPTION
This should fix issue #88

Angular allows to enable different source map kinds, and therefore the schema validation should allow it too.
This has been fixed in #99 but only merged into a previous version.

This PR resolves the issue on the main working branch `cli8`