### PR TITLE
Fix dev-server-plus for Angular 13

### DIFF
--- a/lib/src/plus-dev-server/schema.json
+++ b/lib/src/plus-dev-server/schema.json
@@ -4,7 +4,6 @@
   "description": "Dev Server target options for Build Facade.",
   "type": "object",
   "properties": {
-
     "extraWebpackConfig": {
       "type": "string",
       "description": "Additional Webpack Config that gets merged with the default config."
@@ -24,25 +23,21 @@
       "description": "es module exporting a configHook function (default export).",
       "default": ""
     },
-
     "plugin": {
       "type": "string",
       "description": "es module exporting a Plugin object (default export). Just used for ng build; not for ng serve",
       "default": ""
     },
-
     "bundleStyles": {
       "type": "boolean",
       "description": "DEPRECATED: Use keepStyles instead",
       "default": true
     },
-
     "keepStyles": {
       "type": "boolean",
       "description": "Used conjunction with 'singleBundle' to explizitly bundle styles",
       "default": true
     },
-
     "browserTarget": {
       "type": "string",
       "description": "A browser builder target to serve in the format of `project:target[:configuration]`. You can also pass in more than one configuration name as a comma-separated list. Example: `project:target:production,staging`.",
@@ -130,110 +125,6 @@
       "type": "boolean",
       "description": "Rebuild on change.",
       "default": true
-    },
-    "hmrWarning": {
-      "type": "boolean",
-      "description": "Show a warning when the --hmr option is enabled.",
-      "default": true,
-      "x-deprecated": "No longer has an effect."
-    },
-    "servePathDefaultWarning": {
-      "type": "boolean",
-      "description": "Show a warning when deploy-url/base-href use unsupported serve path values.",
-      "default": true,
-      "x-deprecated": "No longer has an effect."
-    },
-    "optimization": {
-      "description": "Enables optimization of the build output. Including minification of scripts and styles, tree-shaking, dead-code elimination, tree-shaking and fonts inlining. For more information, see https://angular.io/guide/workspace-config#optimization-configuration.",
-      "x-user-analytics": 16,
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "scripts": {
-              "type": "boolean",
-              "description": "Enables optimization of the scripts output.",
-              "default": true
-            },
-            "styles": {
-              "type": "boolean",
-              "description": "Enables optimization of the styles output.",
-              "default": true
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "boolean"
-        }
-      ],
-      "x-deprecated": "Use the \"optimization\" option in the browser builder instead."
-    },
-    "aot": {
-      "type": "boolean",
-      "description": "Build using Ahead of Time compilation.",
-      "x-user-analytics": 13,
-      "x-deprecated": "Use the \"aot\" option in the browser builder instead."
-    },
-    "sourceMap": {
-      "description": "Output source maps for scripts and styles. For more information, see https://angular.io/guide/workspace-config#source-map-configuration.",
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "scripts": {
-              "type": "boolean",
-              "description": "Output source maps for all scripts.",
-              "default": true
-            },
-            "styles": {
-              "type": "boolean",
-              "description": "Output source maps for all styles.",
-              "default": true
-            },
-            "hidden": {
-              "type": "boolean",
-              "description": "Output source maps used for error reporting tools.",
-              "default": false
-            },
-            "vendor": {
-              "type": "boolean",
-              "description": "Resolve vendor packages source maps.",
-              "default": false
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "boolean"
-        }
-      ],
-      "x-deprecated": "Use the \"sourceMap\" option in the browser builder instead."
-    },
-    "vendorChunk": {
-      "type": "boolean",
-      "description": "Generate a seperate bundle containing only vendor libraries. This option should only used for development.",
-      "x-deprecated": "Use the \"vendorChunk\" option in the browser builder instead."
-    },
-    "commonChunk": {
-      "type": "boolean",
-      "description": "Generate a seperate bundle containing code used across multiple bundles.",
-      "x-deprecated": "Use the \"commonChunk\" option in the browser builder instead."
-    },
-    "baseHref": {
-      "type": "string",
-      "description": "Base url for the application being built.",
-      "x-deprecated": "Use the \"baseHref\" option in the browser builder instead."
-    },
-    "deployUrl": {
-      "type": "string",
-      "description": "URL where files will be deployed.",
-      "x-deprecated": "Use the \"deployUrl\" option in the browser builder instead."
-    },
-    "progress": {
-      "type": "boolean",
-      "description": "Log progress to the console while building.",
-      "x-deprecated": "Use the \"progress\" option in the browser builder instead."
     },
     "poll": {
       "type": "number",


### PR DESCRIPTION
This PR addresses #307. Looks like a few options were removed in the Angular 13 upgrade that cause the `ng serve` command to fail. Removing the entries from `schema.json` fixes the issue.